### PR TITLE
Avoid conflict with bundled extension when developing the extension

### DIFF
--- a/build-config.js
+++ b/build-config.js
@@ -14,12 +14,12 @@ const targetBrowser = process.env.TARGET_BROWSER;
 const ui = process.env.UI;
 
 let extensionBuildEnvironment;
-if (process.env.CIRCLECI === "true") {
+if (process.env.MC === "1") {
+  extensionBuildEnvironment = "mozilla";
+} else if (process.env.CIRCLECI === "true") {
   extensionBuildEnvironment = "circleci";
 } else if (process.env.CI === "true") {
   extensionBuildEnvironment = "ci";
-} else if (process.env.MC === "1") {
-  extensionBuildEnvironment = "mozilla";
 } else {
   extensionBuildEnvironment = "local";
 }

--- a/build-config.js
+++ b/build-config.js
@@ -18,6 +18,8 @@ if (process.env.CIRCLECI === "true") {
   extensionBuildEnvironment = "circleci";
 } else if (process.env.CI === "true") {
   extensionBuildEnvironment = "ci";
+} else if (process.env.MC === "1") {
+  extensionBuildEnvironment = "mozilla";
 } else {
   extensionBuildEnvironment = "local";
 }
@@ -27,7 +29,11 @@ if (targetEnvironment !== "production") {
 
 const extensionId =
   ui === "firefox-infobar-ui"
-    ? "firefox-translations@mozilla.org"
+    ? `${
+        process.env.MC === "1"
+          ? "firefox-translations@mozilla.org"
+          : "firefox-infobar-ui-bergamot-browser-extension@browser.mt"
+      }`
     : "bergamot-browser-extension@browser.mt";
 
 const buildPath = path.join(

--- a/web-ext-config.js
+++ b/web-ext-config.js
@@ -58,6 +58,7 @@ if (targetBrowser === "firefox") {
     "about:debugging#/runtime/this-firefox",
   ];
   defaultConfig.run.pref = [
+    `extensions.translations.disabled=true`,
     "extensions.experiments.enabled=true",
     "browser.proton.enabled=true",
     "dom.postMessage.sharedArrayBuffer.bypassCOOP_COEP.insecure.enabled=true",


### PR DESCRIPTION
Introduces the following changes to avoid conflicts when developing the extension using Nightly that already has a copy of the extension bundled:
* Only use `firefox-translations@mozilla.org` as extension id if the MC env var is set to "1" - IMPORTANT: The m-c import script must set this env var in the future!
* The `firefox-infobar-ui-bergamot-browser-extension@browser.mt` extension id is used otherwise
* Disable the nightly-bundled extension when launching our development version of the extension, avoiding conflicts