### PR TITLE
Remove locale from download link in install.md

### DIFF
--- a/user/install.html
+++ b/user/install.html
@@ -176,7 +176,7 @@
 <p>This document outlines how to enable the pre-released version of Firefox Translations which comes bundled with Firefox Nightly.</p>
 <h3><a class="header" href="#configuring-nightly-to-enable-the-extension" id="configuring-nightly-to-enable-the-extension">Configuring Nightly to enable the extension</a></h3>
 <ul>
-<li>Download and install Firefox Nightly (English or German edition) from <a href="https://www.mozilla.org/en-US/firefox/all/#product-desktop-nightly">https://www.mozilla.org/en-US/firefox/all/#product-desktop-nightly</a>.</li>
+<li>Download and install Firefox Nightly (English or German edition) from <a href="https://www.mozilla.org/firefox/all/#product-desktop-nightly">https://www.mozilla.org/en-US/firefox/all/#product-desktop-nightly</a>.</li>
 <li>Start Firefox Nightly</li>
 <li><a href="https://support.mozilla.org/kb/profile-manager-create-remove-switch-firefox-profiles">Create a new Firefox profile</a>. A new profile isolates this testing from your normal browsing profile, and protects your normal browser.</li>
 <li>Activate the new translation user interface by going to <code>about:config</code>, clicking the “Accept the Risk and Continue” button, searching for the <code>extensions.translations.disabled</code> Boolean preference, and toggling the preference to <code>false</code> by clicking the toggle button</li>


### PR DESCRIPTION
This is so if someone had en-CA or another English locale set as their browser default, they would get that version of Firefox.