### PR TITLE
Update extension to use major.minor versioning scheme

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
-  "version": "1.3.4",
+  "version": "1.3",
   "default_locale": "en_US",
   "applications": {
     "gecko": {

--- a/package.json
+++ b/package.json
@@ -26,5 +26,5 @@
     "web-ext": "^7.6.2",
     "markdown": "^0.5.0"
   },
-  "version": "1.3.4"
+  "version": "1.3"
 }

--- a/scripts/manifest-dev-android.json
+++ b/scripts/manifest-dev-android.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
     "name": "__MSG_extensionName__",
     "description": "__MSG_extensionDescription__",
-    "version": "1.3.4",
+    "version": "1.3",
     "default_locale": "en_US",
     "applications": {
       "gecko": {

--- a/scripts/manifest.json
+++ b/scripts/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
-  "version": "1.3.4",
+  "version": "1.3",
   "default_locale": "en_US",
   "applications": {
     "gecko": {


### PR DESCRIPTION
This change is needed for https://github.com/mozilla-extensions/xpi-manifest/pull/215

In [Bug 1793925](https://bugzilla.mozilla.org/show_bug.cgi?id=1793925), Firefox Desktop started to emit warnings when an extension's version doesn't match the format specified in the [MDN docs](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version#version_format).

To comply with this format, we need to drop the patch version on the add on pipeline web extensions.

The pipeline will now generate versions as `major.minor.date.time`